### PR TITLE
Add support for parsing multi-line authors

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "joi": "^10.4.1",
     "joi-assert": "^0.0.3",
-    "parsimmon": "^1.2.0",
+    "parsimmon": "jneen/parsimmon#365a5e3ff9b3a80638b2b1ecf8b4201abccc9815",
     "xregexp": "^3.1.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "joi": "^10.4.1",
     "joi-assert": "^0.0.3",
-    "parsimmon": "jneen/parsimmon#365a5e3ff9b3a80638b2b1ecf8b4201abccc9815",
+    "parsimmon": "^1.3.0",
     "xregexp": "^3.1.1"
   },
   "devDependencies": {

--- a/src/parser/lax.ts
+++ b/src/parser/lax.ts
@@ -122,10 +122,15 @@ export let project: P.Parser<model.Project[]> = P.string('// Project: ')
 	.skip(optTabSpace);
 
 export let authors: P.Parser<model.Author[]> = P.string('// Definitions by: ')
-	.then(P.seq(
-		person,
-		separatorComma.then(person).many()
-	))
+	.then(P.alt(
+		P.seq(
+			person.notFollowedBy(separatorComma),
+			linebreak.skip(P.string('//                 ')).then(person).many()
+		),
+		P.seq(
+			person,
+			separatorComma.then(person).many()
+		)))
 	.map((arr) => {
 		let ret = <model.Author[]> arr[1];
 		ret.unshift(<model.Author> arr[0]);

--- a/test/fixtures/headers/jquery/fields.yml
+++ b/test/fixtures/headers/jquery/fields.yml
@@ -47,9 +47,6 @@
         name: Andrew Gaspar
         url: "https://github.com/AndrewGaspar"
       -
-        name: James Harrison Fisher
-        url: "https://github.com/jameshfisher"
-      -
         name: Seikichi Kondo
         url: "https://github.com/seikichi"
       -
@@ -64,5 +61,14 @@
       -
         name: John Reilly
         url: "https://github.com/johnnyreilly"
+      -
+        name: Dick van den Brink
+        url: "https://github.com/DickvdBrink"
+      -
+        name: Thomas Schulz
+        url: "https://github.com/King2500"
+      -
+        name: Leonard Thieu
+        url: "https://github.com/leonard-thieu"
     repository:
-      url: "https://github.com/borisyankov/DefinitelyTyped"
+      url: "https://github.com/DefinitelyTyped/DefinitelyTyped"

--- a/test/fixtures/headers/jquery/header.txt
+++ b/test/fixtures/headers/jquery/header.txt
@@ -1,4 +1,24 @@
 // Type definitions for jQuery 1.10.x / 2.0.x
 // Project: http://jquery.com/
-// Definitions by: Boris Yankov <https://github.com/borisyankov/>, Christian Hoffmeister <https://github.com/choffmeister>, Steve Fenton <https://github.com/Steve-Fenton>, Diullei Gomes <https://github.com/Diullei>, Tass Iliopoulos <https://github.com/tasoili>, Jason Swearingen <https://github.com/jasons-novaleaf>, Sean Hill <https://github.com/seanski>, Guus Goossens <https://github.com/Guuz>, Kelly Summerlin <https://github.com/ksummerlin>, Basarat Ali Syed <https://github.com/basarat>, Nicholas Wolverson <https://github.com/nwolverson>, Derek Cicerone <https://github.com/derekcicerone>, Andrew Gaspar <https://github.com/AndrewGaspar>, James Harrison Fisher <https://github.com/jameshfisher>, Seikichi Kondo <https://github.com/seikichi>, Benjamin Jackman <https://github.com/benjaminjackman>, Poul Sorensen <https://github.com/s093294>, Josh Strobl <https://github.com/JoshStrobl>, John Reilly <https://github.com/johnnyreilly/>
-// Definitions: https://github.com/borisyankov/DefinitelyTyped
+// Definitions by: Boris Yankov <https://github.com/borisyankov/>
+//                 Christian Hoffmeister <https://github.com/choffmeister>
+//                 Steve Fenton <https://github.com/Steve-Fenton>
+//                 Diullei Gomes <https://github.com/Diullei>
+//                 Tass Iliopoulos <https://github.com/tasoili>
+//                 Jason Swearingen <https://github.com/jasons-novaleaf>
+//                 Sean Hill <https://github.com/seanski>
+//                 Guus Goossens <https://github.com/Guuz>
+//                 Kelly Summerlin <https://github.com/ksummerlin>
+//                 Basarat Ali Syed <https://github.com/basarat>
+//                 Nicholas Wolverson <https://github.com/nwolverson>
+//                 Derek Cicerone <https://github.com/derekcicerone>
+//                 Andrew Gaspar <https://github.com/AndrewGaspar>
+//                 Seikichi Kondo <https://github.com/seikichi>
+//                 Benjamin Jackman <https://github.com/benjaminjackman>
+//                 Poul Sorensen <https://github.com/s093294>
+//                 Josh Strobl <https://github.com/JoshStrobl>
+//                 John Reilly <https://github.com/johnnyreilly/>
+//                 Dick van den Brink <https://github.com/DickvdBrink>
+//                 Thomas Schulz <https://github.com/King2500>
+//                 Leonard Thieu <https://github.com/leonard-thieu>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/typings/parsimmon/index.d.ts
+++ b/typings/parsimmon/index.d.ts
@@ -1,0 +1,7 @@
+import * as Parsimmon from 'parsimmon';
+
+declare module 'parsimmon' {
+    interface Parser<T> {
+        notFollowedBy<TParser>(parser: Parser<TParser>): this;
+    }
+}


### PR DESCRIPTION
Fixes DefinitelyTyped/dt-review-tool#7.

~~**Note**: `parsimmon` references a commit because 1.3.0 hasn't been released yet. See jneen/parsimmon#162.~~

`typings/parsimmon/index.d.ts` can be removed when https://github.com/DefinitelyTyped/DefinitelyTyped/pull/16790 is merged.